### PR TITLE
Windows implementation

### DIFF
--- a/_modules/nebula_osquery.py
+++ b/_modules/nebula_osquery.py
@@ -140,7 +140,7 @@ def queries(query_group,
             'result': True,
         }
 
-        cmd = ['osqueryi', '--json', sql]
+        cmd = ['osqueryi', '--json', query_sql]
         res = __salt__['cmd.run_all'](cmd)
         if res['retcode'] == 0:
             query_ret['data'] = json.loads(res['stdout'])

--- a/_modules/nebula_osquery.py
+++ b/_modules/nebula_osquery.py
@@ -29,6 +29,7 @@ nebula_osquery:
 from __future__ import absolute_import
 
 import copy
+import json
 import logging
 import os
 import sys

--- a/_modules/nebula_osquery.py
+++ b/_modules/nebula_osquery.py
@@ -109,8 +109,25 @@ def queries(query_group,
     if salt.utils.is_windows():
         win_version = __grains__['osfullname']
         if '2012' not in win_version and '2016' not in win_version:
-            log.debug('osquery does not run on windows versions earlier than Server 2012 and Windows 8')
-            return None
+            log.error('osquery does not run on windows versions earlier than Server 2012 and Windows 8')
+            if query_group == 'day':
+                ret = []
+                ret.append(
+                        {'fallback_osfinger': {
+                             'data': [{'osfinger': __grains__.get('osfinger', __grains__.get('osfullname'))}],
+                             'result': True
+                        }}
+                )
+                ret.append(
+                        {'fallback_error': {
+                             'data': 'osqueryi is installed but not compatible with this version of windows',
+                             'result': True
+                        }}
+                )
+                return ret
+            else:
+               return None
+                   
 
     orig_filename = query_file
     query_file = __salt__['cp.cache_file'](query_file)

--- a/_modules/nebula_osquery.py
+++ b/_modules/nebula_osquery.py
@@ -107,18 +107,20 @@ def queries(query_group,
 
     if salt.utils.is_windows():
         win_version = __grains__['osfullname']
-        if '2012','2016' in win_version:
+        if '2012' in win_version or '2016' in win_version:
             osquery_in_path = __salt__['cmd.run']('osqueryi --help')
-            if 'osquery command line flags:' in osquery_in_path:
-                win_osquery = True
-            else:
+            if 'osquery command line flags:' not in osquery_in_path:
                 log.debug('osqueryi.exe not installed in system path')
                 return None
         else: 
             log.debug('osquery does not run on windows versions earlier than Server 2012 and Windows 8')
             return None
 
+    orig_filename = query_file
     query_file = __salt__['cp.cache_file'](query_file)
+    if query_file is None:
+        log.error('Could not find file {0}.'.format(orig_filename))
+        return None
     with open(query_file, 'r') as fh:
         query_data = yaml.safe_load(fh)
 

--- a/hubblestack_nebula/hubblestack_nebula_win_queries.yaml
+++ b/hubblestack_nebula/hubblestack_nebula_win_queries.yaml
@@ -1,0 +1,11 @@
+fifteen_min:
+  - query_name: running_procs
+    query: SELECT name AS process, pid AS process_id, cmdline, on_disk, resident_size AS mem_used, parent, path, FROM processes
+hour:
+  - query_name: stuff_with_things
+    query: SELECT * FROM processes
+day:
+  - query_name: os_info
+    query: SELECT * FROM system_info
+  - query_name: interface_addresses
+    query: SELECT * FROM interface_addresses

--- a/hubblestack_nebula/hubblestack_nebula_win_queries.yaml
+++ b/hubblestack_nebula/hubblestack_nebula_win_queries.yaml
@@ -1,6 +1,6 @@
 fifteen_min:
   - query_name: running_procs
-    query: SELECT name AS process, pid AS process_id, cmdline, on_disk, resident_size AS mem_used, parent, path, FROM processes
+    query: SELECT name AS process, pid AS process_id, cmdline, on_disk, resident_size AS mem_used, parent, path FROM processes
 hour:
   - query_name: stuff_with_things
     query: SELECT * FROM processes


### PR DESCRIPTION
This Change allows Windows Server 2012 (and Windows 8) to run Windows Nebula.  If you have an earlier version, it will throw an error and return just the base OS, or nothing.  Otherwise it works just as the linux version does.  The current queries configured in the yaml are very basic, since the osquery does not have the same options for windows as it does linux.  A future update to the yaml will be needed to get more useful information.